### PR TITLE
CentOS 6.0 to 6.2 uses the same openjdk package

### DIFF
--- a/manifests/classes/packages.pp
+++ b/manifests/classes/packages.pp
@@ -11,7 +11,7 @@ class solr::packages {
 			ensure => present,
 			name => $operatingsystem ? {
 				'Centos' => $operatingsystemrelease ? {
-					'6.0' => "java-1.6.0-openjdk.$hardwaremodel",
+					/6\.[0-2]/ => "java-1.6.0-openjdk.$hardwaremodel",
 					'*' => 'openjdk-6-jre',
 				},
 				'Debian' => 'openjdk-6-jre-headless',


### PR DESCRIPTION
Added CentOS 6.2 (and 6.1).
